### PR TITLE
logger::log_last_execute_time(), source last extract time to be used …

### DIFF
--- a/classes/logger.php
+++ b/classes/logger.php
@@ -235,4 +235,17 @@ final class logger {
         return $DB->get_fieldset_sql("SELECT runid FROM {" . self::TABLE . "} GROUP BY runid ORDER BY runid");
     }
 
+    /**
+     * Return last run for task
+     *
+     * @return array
+     */
+    public function get_last_execute_time() {
+        global $DB;
+
+        return $DB->get_field_sql(
+            "SELECT time FROM {" . self::TABLE . "} WHERE taskid = ? AND action = 'execute' AND info = 'Task started' ORDER BY time DESC LIMIT 1",
+            [$this->taskid]
+        );
+    }
 }

--- a/classes/source/source_base.php
+++ b/classes/source/source_base.php
@@ -39,6 +39,13 @@ abstract class source_base extends common_base implements source_interface {
     protected $data;
 
     /**
+     * Last extract timestamp
+     *
+     * @var int
+     */
+    protected $lastextracttime;
+
+    /**
      * Return available source options.
      *
      * @return array A list of existing source classes.
@@ -54,4 +61,12 @@ abstract class source_base extends common_base implements source_interface {
         );
     }
 
+    /**
+     * Set last extract timestamp
+     *
+     * @param int $lastextracttime
+     */
+    final public function set_last_extract_time($lastextracttime) {
+        $this->lastextracttime = $lastextracttime;
+    }
 }

--- a/classes/source/source_database.php
+++ b/classes/source/source_database.php
@@ -55,9 +55,8 @@ class source_database extends source_base {
      * @inheritdoc
      */
     public function extract() {
-        global $DB;
-
-        $recordset = $DB->get_recordset_sql($this->get_settings()['querysql']);
+        $sql = $this->tool_etl_substitute_time_tokens($this->get_settings()['querysql'], $this->lastextracttime, time());
+        $recordset = $this->tool_etl_execute_query($sql);
 
         $arraytoprocess = array();
         while ($recordset->valid()) {

--- a/classes/task.php
+++ b/classes/task.php
@@ -343,6 +343,8 @@ class task implements task_interface {
     public function execute() {
         try {
             if ($this->is_enabled() && $this->schedule->is_time()) {
+                $this->source->set_last_extract_time($this->log_last_execute_time());
+
                 $this->log('execute', 'Task started');
 
                 $this->schedule->next();
@@ -373,5 +375,17 @@ class task implements task_interface {
         logger::get_instance()->set_task_id($this->id);
         logger::get_instance()->set_element('Task');
         logger::get_instance()->add_to_log($logtype, $action, $info, $trace);
+    }
+
+    /**
+     * Get last exec time from log
+     *
+     * @return int timestamp
+     *
+     * @throws \coding_exception
+     */
+    protected function log_last_execute_time() {
+        logger::get_instance()->set_task_id($this->id);
+        return logger::get_instance()->get_last_execute_time();
     }
 }

--- a/tests/logger_test.php
+++ b/tests/logger_test.php
@@ -173,4 +173,20 @@ class tool_etl_logger_testcase extends advanced_testcase {
         $this->assertEquals($expected, logger::get_existing_run_ids());
     }
 
+    public function test_get_last_execute_time() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $logger = logger::get_instance();
+        $logger->set_task_id(666);
+
+        $lasttime = $logger->get_last_execute_time();
+        $this->assertFalse($lasttime);
+
+        $now = time();
+        $logger->add_to_log(logger::TYPE_INFO, 'execute', 'Test started');
+        $lasttime = $logger->get_last_execute_time();
+        $this->assertTrue($lasttime - $now <= 1);
+    }
 }


### PR DESCRIPTION
…as daily start time

Daily scheduling is time sensitive, so we must keep track of the last run.