### PR TITLE
Fix unit test errors.

### DIFF
--- a/tests/common/common_base_test.php
+++ b/tests/common/common_base_test.php
@@ -55,6 +55,7 @@ class tool_etl_common_base_testcase extends advanced_testcase {
      * @expectedExceptionMessage Invalid type Random type
      */
     public function test_throw_exception_when_get_options_for_invalid_type() {
+        $this->expectExceptionMessage('Invalid type Random type');
         $options = common_base::options('Random type');
     }
 
@@ -78,6 +79,7 @@ class tool_etl_common_base_testcase extends advanced_testcase {
      * @expectedExceptionMessage Can not initialise element. Class tool_etl\random_type\RandonName is not exist
      */
     public function test_throw_exception_when_init_invalid_type() {
+        $this->expectExceptionMessage('Can not initialise element. Class tool_etl\random_type\RandonName is not exist');
         $options = common_base::init('random_type', 'RandonName');
     }
 

--- a/tests/config_field_test.php
+++ b/tests/config_field_test.php
@@ -37,6 +37,7 @@ class tool_etl_config_field_testcase extends advanced_testcase {
      */
     public function test_exception_when_getting_unknown_parameter() {
         $instance = new config_field('test_name', 'Test title');
+        $this->expectExceptionMessage('Unknown parameter bla');
         $instance->bla;
     }
 

--- a/tests/data_test.php
+++ b/tests/data_test.php
@@ -64,6 +64,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_if_format_is_not_string() {
         $data = new data();
+        $this->expectExceptionMessage('Format should be a string');
         $data->get_data(array());
     }
 
@@ -73,6 +74,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_on_unknown_format() {
         $data = new data();
+        $this->expectExceptionMessage('Data is not available in bla format');
         $data->get_data('bla');
     }
 
@@ -82,6 +84,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_on_files_format() {
         $data = new data();
+        $this->expectExceptionMessage('Data is not available in files format');
         $data->get_data('files');
     }
 
@@ -91,6 +94,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_on_string_format() {
         $data = new data();
+        $this->expectExceptionMessage('Data is not available in string format');
         $data->get_data('string');
     }
 
@@ -100,6 +104,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_on_array_format() {
         $data = new data();
+        $this->expectExceptionMessage('Data is not available in array format');
         $data->get_data('array');
     }
 
@@ -109,6 +114,7 @@ class tool_etl_data_testcase extends advanced_testcase {
      */
     public function test_get_data_throwing_exception_on_object_format() {
         $data = new data();
+        $this->expectExceptionMessage('Data is not available in object format');
         $data->get_data('object');
     }
 

--- a/tests/logger_test.php
+++ b/tests/logger_test.php
@@ -49,6 +49,7 @@ class tool_etl_logger_testcase extends advanced_testcase {
     public function test_throw_exception_when_clone() {
         $this->resetAfterTest();
         $logger = logger::get_instance();
+        $this->expectExceptionMessage('Cannot clone singleton');
 
         $clone = clone $logger;
     }
@@ -60,6 +61,7 @@ class tool_etl_logger_testcase extends advanced_testcase {
     public function test_throw_exception_if_task_id_is_not_set() {
         $logger = logger::get_instance();
         $logger->set_element('Test element');
+        $this->expectExceptionMessage('Task or Element is not set. Can not write to the log');
 
         $logger->add_to_log(logger::TYPE_ERROR, 'test');
     }
@@ -72,6 +74,7 @@ class tool_etl_logger_testcase extends advanced_testcase {
         $logger = logger::get_instance();
         $logger->set_element(null);
         $logger->set_task_id(777);
+        $this->expectExceptionMessage('Task or Element is not set. Can not write to the log');
 
         $logger->add_to_log(logger::TYPE_ERROR, 'test');
     }

--- a/tests/processor/processor_default_test.php
+++ b/tests/processor/processor_default_test.php
@@ -87,6 +87,7 @@ class tool_etl_processor_default_testcase extends advanced_testcase {
      */
     public function test_throw_exception_if_source_and_target_are_not_set() {
         $processor = new processor_default();
+        $this->expectExceptionMessage('Can not process. Source and target must be set!');
         $processor->process();
     }
 
@@ -98,6 +99,7 @@ class tool_etl_processor_default_testcase extends advanced_testcase {
     public function test_throw_exception_if_source_is_not_set() {
         $processor = new processor_default();
         $processor->set_source($this->source);
+        $this->expectExceptionMessage('Can not process. Source and target must be set!');
         $processor->process();
     }
 
@@ -109,6 +111,7 @@ class tool_etl_processor_default_testcase extends advanced_testcase {
     public function test_throw_exception_if_target_is_not_set() {
         $processor = new processor_default();
         $processor->set_target($this->target);
+        $this->expectExceptionMessage('Can not process. Source and target must be set!');
         $processor->process();
     }
 

--- a/tests/result_test.php
+++ b/tests/result_test.php
@@ -57,6 +57,7 @@ class tool_etl_result_testcase extends advanced_testcase {
      * @expectedExceptionMessage Format should be not empty string
      */
     public function test_validate_format_when_add_result($format) {
+        $this->expectExceptionMessage('Format should be not empty string');
         $this->resultinstance->add_result($format, true);
     }
 
@@ -66,6 +67,7 @@ class tool_etl_result_testcase extends advanced_testcase {
      * @expectedExceptionMessage Format should be not empty string
      */
     public function test_validate_format_when_get_result($format) {
+        $this->expectExceptionMessage('Format should be not empty string');
         $this->resultinstance->get_result($format);
     }
 

--- a/tests/source/source_folder_test.php
+++ b/tests/source/source_folder_test.php
@@ -88,7 +88,7 @@ class tool_etl_source_folder_testcase extends advanced_testcase {
 
         $this->assertEquals('text', $elements[0]->getType());
         $this->assertEquals('text', $elements[1]->getType());
-        $this->assertContains('checkbox', $elements[2]->getType());
+        $this->assertStringContainsString('checkbox', $elements[2]->getType());
 
         $this->assertEquals('source_folder-folder', $elements[0]->getName());
         $this->assertEquals('source_folder-fileregex', $elements[1]->getName());
@@ -145,6 +145,7 @@ class tool_etl_source_folder_testcase extends advanced_testcase {
      * @expectedExceptionMessage Server folder source is not available!
      */
     public function test_exception_thrown_when_extract_and_source_is_not_available() {
+        $this->expectExceptionMessage('Server folder source is not available!');
         $this->source->extract();
     }
 
@@ -179,10 +180,10 @@ class tool_etl_source_folder_testcase extends advanced_testcase {
         $this->assertTrue(file_exists($testfile3));
         $this->assertTrue(file_exists($testfile4));
 
-        $this->assertRegExp('#' . $pattern . basename($testfile1) . '#', $files[0]);
-        $this->assertRegExp('#' . $pattern . basename($testfile2) . '#', $files[1]);
-        $this->assertRegExp('#' . $pattern . basename($testfile3) . '#', $files[2]);
-        $this->assertRegExp('#' . $pattern . basename($testfile4) . '#', $files[3]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile1) . '#', $files[0]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile2) . '#', $files[1]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile3) . '#', $files[2]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile4) . '#', $files[3]);
 
         // Filter files by regex and delete files after loading.
         $this->source = new source_folder(array('folder' => $testfolder, 'fileregex' => '/test[1-3].txt/', 'delete' => 1));
@@ -199,9 +200,9 @@ class tool_etl_source_folder_testcase extends advanced_testcase {
         $this->assertFalse(file_exists($testfile3));
         $this->assertTrue(file_exists($testfile4));
 
-        $this->assertRegExp('#' . $pattern . basename($testfile1) . '#', $files[0]);
-        $this->assertRegExp('#' . $pattern . basename($testfile2) . '#', $files[1]);
-        $this->assertRegExp('#' . $pattern . basename($testfile3) . '#', $files[2]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile1) . '#', $files[0]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile2) . '#', $files[1]);
+        $this->assertMatchesRegularExpression('#' . $pattern . basename($testfile3) . '#', $files[2]);
 
     }
 

--- a/tests/target/target_dataroot_test.php
+++ b/tests/target/target_dataroot_test.php
@@ -97,13 +97,13 @@ class tool_etl_target_dataroot_testcase extends advanced_testcase {
         $this->assertCount(8, $elements);
 
         $this->assertEquals('text', $elements[0]->getType());
-        $this->assertContains('checkbox', $elements[1]->getType());
+        $this->assertStringContainsString('checkbox', $elements[1]->getType());
         $this->assertEquals('text', $elements[2]->getType());
-        $this->assertContains('checkbox', $elements[3]->getType());
-        $this->assertContains('checkbox', $elements[4]->getType());
+        $this->assertStringContainsString('checkbox', $elements[3]->getType());
+        $this->assertStringContainsString('checkbox', $elements[4]->getType());
         $this->assertEquals('select', $elements[5]->getType());
         $this->assertEquals('text', $elements[6]->getType());
-        $this->assertContains('checkbox', $elements[7]->getType());
+        $this->assertStringContainsString('checkbox', $elements[7]->getType());
 
         $this->assertEquals('target_dataroot-path', $elements[0]->getName());
         $this->assertEquals('target_dataroot-clreateifnotexist', $elements[1]->getName());

--- a/tests/target/target_sftp_key_test.php
+++ b/tests/target/target_sftp_key_test.php
@@ -277,7 +277,7 @@ class tool_etl_target_sftp_key_testcase extends advanced_testcase {
 
         $messages = $sink->get_messages();
         $this->assertCount(1, $messages);
-        $this->assertContains('load_data error', $messages[0]->subject);
+        $this->assertStringContainsString('load_data error', $messages[0]->subject);
         $this->assertEquals($email, $messages[0]->to);
 
         $this->assertFalse($actual->get_result('files'));


### PR DESCRIPTION
The patch fixes the following categories of errors:

 - Handling of exceptions such as \coding_exception and checking exception messages
 - Refactoring deprecated calls such as assertRegExp()
 - Changing assertContains() to assertStringContainsString()