### PR TITLE
Fix unit test errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: Run all tests
+# .github/workflows/ci.yml
+name: ci
 
 # Run this workflow on push and on pull_request.
 on: [push, pull_request]
@@ -42,8 +43,6 @@ jobs:
           - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '14.15', database: 'pgsql'}
           - {moodle-branch: 'MOODLE_310_STABLE', php: '7.4', node: '14.15.1', database: 'mariadb'}
           - {moodle-branch: 'MOODLE_310_STABLE', php: '7.4', node: '14.15.1', database: 'pgsql'}
-          - {moodle-branch: 'MOODLE_311_STABLE', php: '7.4', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_311_STABLE', php: '7.4', node: '14.15.1', database: 'pgsql'}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ For example it is often used to slightly massage data before using it with Totar
 
 ## Branches
 
-| Moodle verion      | Branch  | PHP        |
-| ------------------ | ------- | ---------- |
+| Moodle version     | Branch  | PHP        |
+|--------------------| ------- | ---------- |
 | Moodle 3.3 to 3.8  | master  | 7.1 - 7.2+ |
-| Moodle 3.9 to 3.11 | master  | 7.2 - 7.4+ |
+| Moodle 3.9 to 3.10 | master  | 7.2 - 7.4+ |
 | Totara 12+         | master  | 5.6 - 7.0+ |
+
+NOTE: Moodle 3.11 is not supported. This is going to be the end of life version of the plugin.
 
 NOTE: There is a fork of this under the MOODLE_35 branch which moves to a sub plugin architecture, and has various improvements:
 

--- a/classes/source/source_url.php
+++ b/classes/source/source_url.php
@@ -33,8 +33,7 @@ use tool_etl\logger;
 
 defined('MOODLE_INTERNAL') || die;
 
-class source_url extends source_base
-{
+class source_url extends source_base {
 
     /**
      * Name of the source.


### PR DESCRIPTION
The patch does the following:

- remove support for Moodle 3.11 and CI tests for this versions. Only the versions 3.5 to 3.10 are supported.
- fix code check errors.